### PR TITLE
0.0.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.2</version>
+                <version>3.5.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -116,38 +116,24 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-        <repository>
-            <id>central</id>
-            <url>https://repo.maven.apache.org/maven2</url>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.15.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>net.hydrius</groupId>
     <artifactId>pacts</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <packaging>jar</packaging>
 
     <name>Pacts</name>
@@ -19,12 +19,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.4</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -15,30 +15,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.15.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.9.3</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
     <build>
         <resources>
             <resource>
@@ -113,6 +89,25 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.21.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.3.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <distributionManagement>
         <repository>
             <id>github</id>
@@ -120,5 +115,71 @@
             <url>https://maven.pkg.github.com/project-hydrius/pacts</url>
         </repository>
     </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>rabbitmq</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/java/src/main/java/net/hydrius/pacts/core/SchemaLoader.java
+++ b/java/src/main/java/net/hydrius/pacts/core/SchemaLoader.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * SchemaLoader class that loads schemas that are bundled with Pacts.
@@ -38,6 +39,7 @@ public class SchemaLoader {
         }
 
         this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
         this.cache = new HashMap<>();
         this.schemaRoot = schemaRoot;
         this.domain = domain;

--- a/java/src/main/java/net/hydrius/pacts/core/Validator.java
+++ b/java/src/main/java/net/hydrius/pacts/core/Validator.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import net.hydrius.pacts.model.Envelope;
 import net.hydrius.pacts.model.Header;
 
@@ -25,6 +26,7 @@ public class Validator {
      */
     public Validator(SchemaLoader schemaLoader) {
         this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
         this.schemaLoader = schemaLoader;
     }
 

--- a/java/src/main/java/net/hydrius/pacts/impl/PactsService.java
+++ b/java/src/main/java/net/hydrius/pacts/impl/PactsService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import net.hydrius.pacts.core.SchemaLoader;
 import net.hydrius.pacts.core.ValidationResult;
 import net.hydrius.pacts.core.Validator;
@@ -27,6 +28,7 @@ public class PactsService {
         this.schemaLoader = schemaLoader;
         this.validator = new Validator(schemaLoader);
         this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
     }
 
     /**

--- a/java/src/test/java/net/hydrius/pacts/spring/PactsConfig.java
+++ b/java/src/test/java/net/hydrius/pacts/spring/PactsConfig.java
@@ -1,0 +1,35 @@
+package net.hydrius.pacts.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.hydrius.pacts.core.SchemaLoader;
+import net.hydrius.pacts.core.Validator;
+import net.hydrius.pacts.impl.PactsService;
+
+@Configuration
+public class PactsConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public SchemaLoader schemaLoader() {
+        return new SchemaLoader("schemas", "bees", "v1");
+    }
+
+    @Bean
+    public Validator validator(SchemaLoader schemaLoader) {
+        return new Validator(schemaLoader);
+    }
+
+    @Bean
+    public PactsService pactsService(SchemaLoader schemaLoader) {
+        return new PactsService(schemaLoader);
+    }
+
+}

--- a/java/src/test/java/net/hydrius/pacts/spring/PactsConfig.java
+++ b/java/src/test/java/net/hydrius/pacts/spring/PactsConfig.java
@@ -1,5 +1,6 @@
 package net.hydrius.pacts.spring;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,7 +15,7 @@ public class PactsConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        return new ObjectMapper().registerModule(new JavaTimeModule());
     }
 
     @Bean

--- a/java/src/test/java/net/hydrius/pacts/spring/RabbitConfig.java
+++ b/java/src/test/java/net/hydrius/pacts/spring/RabbitConfig.java
@@ -5,8 +5,6 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.RabbitMQContainer;
@@ -16,7 +14,7 @@ import static net.hydrius.pacts.spring.SpringBootMessageTest.*;
 @Configuration
 public class RabbitConfig {
 
-    @Bean
+    @Bean(initMethod = "start", destroyMethod = "stop")
     public RabbitMQContainer rabbitMQContainer() {
         RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.13.1");
         container.start();
@@ -59,20 +57,6 @@ public class RabbitConfig {
     @Bean
     Binding binding(Queue q, TopicExchange ex) {
         return BindingBuilder.bind(q).to(ex).with(ROUTING_KEY);
-    }
-
-    @Bean
-    public SimpleMessageListenerContainer messageListenerContainer(ConnectionFactory cf, MessageListenerAdapter listenerAdapter) {
-        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-        container.setConnectionFactory(cf);
-        container.setQueueNames(QUEUE);
-        container.setMessageListener(listenerAdapter);
-        return container;
-    }
-
-    @Bean
-    public MessageListenerAdapter listenerAdapter(TestListener receiver) {
-        return new MessageListenerAdapter(receiver, "handleMessage");
     }
 
 }

--- a/java/src/test/java/net/hydrius/pacts/spring/RabbitConfig.java
+++ b/java/src/test/java/net/hydrius/pacts/spring/RabbitConfig.java
@@ -1,0 +1,78 @@
+package net.hydrius.pacts.spring;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.RabbitMQContainer;
+
+import static net.hydrius.pacts.spring.SpringBootMessageTest.*;
+
+@Configuration
+public class RabbitConfig {
+
+    @Bean
+    public RabbitMQContainer rabbitMQContainer() {
+        RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.13.1");
+        container.start();
+        return container;
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory(RabbitMQContainer rabbitMQContainer) {
+        CachingConnectionFactory factory = new CachingConnectionFactory(
+                rabbitMQContainer.getHost(),
+                rabbitMQContainer.getMappedPort(5672)
+        );
+        factory.setUsername(rabbitMQContainer.getAdminUsername());
+        factory.setPassword(rabbitMQContainer.getAdminPassword());
+
+        return factory;
+    }
+
+    @Bean
+    public AmqpAdmin amqpAdmin(ConnectionFactory cf) {
+        return new RabbitAdmin(cf);
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory cf) {
+        return new RabbitTemplate(cf);
+    }
+
+    @Bean
+    TopicExchange exchange() {
+        return new TopicExchange(EXCHANGE, true, false);
+
+    }
+
+    @Bean
+    Queue queue() {
+        return new Queue(QUEUE, true);
+    }
+
+    @Bean
+    Binding binding(Queue q, TopicExchange ex) {
+        return BindingBuilder.bind(q).to(ex).with(ROUTING_KEY);
+    }
+
+    @Bean
+    public SimpleMessageListenerContainer messageListenerContainer(ConnectionFactory cf, MessageListenerAdapter listenerAdapter) {
+        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+        container.setConnectionFactory(cf);
+        container.setQueueNames(QUEUE);
+        container.setMessageListener(listenerAdapter);
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(TestListener receiver) {
+        return new MessageListenerAdapter(receiver, "handleMessage");
+    }
+
+}

--- a/java/src/test/java/net/hydrius/pacts/spring/SpringBootMessageTest.java
+++ b/java/src/test/java/net/hydrius/pacts/spring/SpringBootMessageTest.java
@@ -1,0 +1,383 @@
+package net.hydrius.pacts.spring;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.hydrius.pacts.core.ValidationResult;
+import net.hydrius.pacts.impl.PactsService;
+import net.hydrius.pacts.model.Envelope;
+
+@Testcontainers
+@SpringBootTest(classes = {
+    PactsConfig.class,
+    RabbitConfig.class,
+    TestListener.class
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SpringBootMessageTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(SpringBootMessageTest.class);
+    public static final String EXCHANGE = "test.request.exchange";
+    public static final String ROUTING_KEY = "test.request.key";
+    public static final String QUEUE = "test.request.queue";
+
+    @Autowired
+    private PactsService pactsService;
+
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    void sendMessage(JsonNode json, String schemaCategory, String schemaName) throws JsonProcessingException {
+        logger.debug("Preparing to send message for schema: {}/{}", schemaCategory, schemaName);
+
+        Envelope envelope = pactsService.createEnvelope(schemaCategory, schemaName, json);
+        String payload = pactsService.toJson(envelope);
+
+        logger.debug("Created envelope with payload size: {} bytes", payload.length());
+
+        MessageProperties props = new MessageProperties();
+        props.setContentType("application/json");
+        props.setTimestamp(Date.from(Instant.now()));
+
+        ValidationResult result = pactsService.validate(envelope);
+        if (!result.isValid()) {
+            logger.error("Validation failed for {}/{}: {}", schemaCategory, schemaName, result.getErrorMessage());
+            throw new IllegalArgumentException("Invalid payload. Error: " + result.getErrorMessage());
+        }
+
+        logger.debug("Validation successful for {}/{}", schemaCategory, schemaName);
+
+        Message message = new Message(payload.getBytes(StandardCharsets.UTF_8), props);
+        rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, message);
+        logger.info("Successfully sent message to exchange '{}' with routing key '{}' - Schema: {}/{}",
+                EXCHANGE, ROUTING_KEY, schemaCategory, schemaName);
+    }
+
+    void sendMessageAndExpectFailure(JsonNode json, String schemaCategory, String schemaName, String expectedErrorSubstring) {
+        logger.debug("Testing expected validation failure for schema: {}/{}", schemaCategory, schemaName);
+
+        try {
+            sendMessage(json, schemaCategory, schemaName);
+            Assertions.fail("Expected validation to fail but it succeeded");
+        } catch (IllegalArgumentException e) {
+            logger.debug("Validation failed as expected: {}", e.getMessage());
+            if (expectedErrorSubstring != null) {
+                Assertions.assertTrue(e.getMessage().contains(expectedErrorSubstring),
+                        "Error message should contain: " + expectedErrorSubstring + ", but was: " + e.getMessage());
+            }
+        } catch (JsonProcessingException e) {
+            logger.error("JSON processing error during validation test", e);
+            Assertions.fail("Expected IllegalArgumentException but got JsonProcessingException: " + e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("Valid player request should process successfully")
+    void goodPayload_processesEnvelopeAndValidates() throws Exception {
+        logger.info("Testing valid player request payload");
+
+        var payload = objectMapper.createObjectNode()
+                .put("request_type", "PLAYER_JOIN")
+                .put("target_id", UUID.randomUUID().toString())
+                .put("date", Instant.now().toString());
+
+        sendMessage(payload, "player", "player_request");
+        logger.info("Valid player request test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Player request missing date should throw validation error")
+    void missingDate_throwsHelpfulError() {
+        logger.info("Testing player request with missing date field");
+
+        var payload = objectMapper.createObjectNode()
+                .put("request_type", "PLAYER_JOIN")
+                .put("target_id", UUID.randomUUID().toString());
+
+        sendMessageAndExpectFailure(payload, "player", "player_request", "date");
+        logger.info("Missing date validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Player request missing target_id should fail validation")
+    void missingTargetId_throwsValidationError() {
+        logger.info("Testing player request with missing target_id field");
+
+        var payload = objectMapper.createObjectNode()
+                .put("request_type", "PLAYER_LEAVE")
+                .put("date", Instant.now().toString());
+
+        sendMessageAndExpectFailure(payload, "player", "player_request", "target_id");
+        logger.info("Missing target_id validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Player request missing request_type should fail validation")
+    void missingRequestType_throwsValidationError() {
+        logger.info("Testing player request with missing request_type field");
+
+        var payload = objectMapper.createObjectNode()
+                .put("target_id", UUID.randomUUID().toString())
+                .put("date", Instant.now().toString());
+
+        sendMessageAndExpectFailure(payload, "player", "player_request", "request_type");
+        logger.info("Missing request_type validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Valid basic inventory item should validate successfully")
+    void validBasicInventoryItem_shouldValidate() {
+        logger.info("Testing valid basic inventory item");
+
+        var payload = objectMapper.createObjectNode()
+                .put("slot", 1)
+                .put("material", "diamond_sword")
+                .put("amount", 1);
+
+        Envelope envelope = pactsService.createEnvelope("inventory", "inventory_item", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertTrue(result.isValid(), "Basic inventory item should be valid: " + result.getErrorMessage());
+        logger.info("Basic inventory item validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Inventory item with enchantments should validate successfully")
+    void inventoryItemWithEnchantments_shouldValidate() {
+        logger.info("Testing inventory item with enchantments");
+
+        ArrayNode enchantments = objectMapper.createArrayNode();
+        ObjectNode enchantment = objectMapper.createObjectNode()
+                .put("enchantment_id", "sharpness")
+                .put("enchantment_level", 5);
+        enchantments.add(enchantment);
+
+        var payload = objectMapper.createObjectNode()
+                .put("slot", 2)
+                .put("material", "diamond_sword")
+                .put("amount", 1)
+                .set("enchantment_data", enchantments);
+
+        Envelope envelope = pactsService.createEnvelope("inventory", "inventory_item", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertTrue(result.isValid(), "Inventory item with enchantments should be valid: " + result.getErrorMessage());
+        logger.info("Inventory item with enchantments validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Inventory item with complex NBT data should validate successfully")
+    void inventoryItemWithComplexNBT_shouldValidate() {
+        logger.info("Testing inventory item with complex NBT data");
+
+        // Create nectar statistics
+        ArrayNode statistics = objectMapper.createArrayNode();
+        ObjectNode stat = objectMapper.createObjectNode()
+                .put("type", "attack_damage")
+                .put("value", 10.5)
+                .put("boosts", 3);
+        statistics.add(stat);
+
+        // Create nectar data
+        ArrayNode nectar = objectMapper.createArrayNode();
+        ObjectNode nectarSlot = objectMapper.createObjectNode()
+                .put("slot", 1)
+                .set("statistics", statistics);
+        nectar.add(nectarSlot);
+
+        // Create NBT data
+        ObjectNode nbtData = objectMapper.createObjectNode()
+                .put("id", "unique_sword_123")
+                .put("rarity", "legendary")
+                .put("level", 50)
+                .put("modifier", "fire_aspect")
+                .set("nectar", nectar);
+
+        var payload = objectMapper.createObjectNode()
+                .put("slot", 3)
+                .put("material", "legendary_sword")
+                .put("amount", 1)
+                .set("nbt_data", nbtData);
+
+        Envelope envelope = pactsService.createEnvelope("inventory", "inventory_item", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertTrue(result.isValid(), "Complex inventory item should be valid: " + result.getErrorMessage());
+        logger.info("Complex inventory item validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Inventory item missing required fields should fail validation")
+    void inventoryItemMissingRequiredFields_shouldFail() {
+        logger.info("Testing inventory item with missing required fields");
+
+        var payload = objectMapper.createObjectNode()
+                .put("slot", 1); // Missing material and amount
+
+        Envelope envelope = pactsService.createEnvelope("inventory", "inventory_item", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertFalse(result.isValid(), "Inventory item with missing fields should be invalid");
+        logger.debug("Validation failed as expected: {}", result.getErrorMessage());
+        logger.info("Missing required fields validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Inventory request with inventory array should validate successfully")
+    void inventoryRequestWithInventoryArray_shouldValidate() {
+        logger.info("Testing inventory request with inventory array");
+
+        ArrayNode inventory = objectMapper.createArrayNode();
+        ObjectNode item = objectMapper.createObjectNode()
+                .put("slot", 1)
+                .put("material", "diamond")
+                .put("amount", 64);
+        inventory.add(item);
+
+        var payload = objectMapper.createObjectNode()
+                .put("date", Instant.now().toString())
+                .put("request_type", "GET_INVENTORY")
+                .put("target_id", UUID.randomUUID().toString())
+                .put("profile_id", UUID.randomUUID().toString())
+                .set("inventory", inventory);
+
+        Envelope envelope = pactsService.createEnvelope("inventory", "inventory_request", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertTrue(result.isValid(), "Inventory request with inventory array should be valid: " + result.getErrorMessage());
+        logger.info("Inventory request with inventory array validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Inventory request with slot should validate successfully")
+    void inventoryRequestWithSlot_shouldValidate() {
+        logger.info("Testing inventory request with slot");
+
+        var payload = objectMapper.createObjectNode()
+                .put("date", Instant.now().toString())
+                .put("request_type", "GET_SLOT")
+                .put("target_id", UUID.randomUUID().toString())
+                .put("profile_id", UUID.randomUUID().toString())
+                .put("slot", 5);
+
+        Envelope envelope = pactsService.createEnvelope("inventory", "inventory_request", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertTrue(result.isValid(), "Inventory request with slot should be valid: " + result.getErrorMessage());
+        logger.info("Inventory request with slot validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Inventory request missing profile_id should fail validation")
+    void inventoryRequestMissingProfileId_shouldFail() {
+        logger.info("Testing inventory request with missing profile_id");
+
+        var payload = objectMapper.createObjectNode()
+                .put("date", Instant.now().toString())
+                .put("request_type", "GET_INVENTORY")
+                .put("target_id", UUID.randomUUID().toString())
+                .put("slot", 1);
+
+        Envelope envelope = pactsService.createEnvelope("inventory", "inventory_request", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertFalse(result.isValid(), "Inventory request without profile_id should be invalid");
+        logger.debug("Validation failed as expected: {}", result.getErrorMessage());
+        logger.info("Missing profile_id validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Valid profile request should validate successfully")
+    void validProfileRequest_shouldValidate() {
+        logger.info("Testing valid profile request");
+
+        var payload = objectMapper.createObjectNode()
+                .put("date", Instant.now().toString())
+                .put("request_type", "GET_PROFILE")
+                .put("target_id", UUID.randomUUID().toString());
+
+        Envelope envelope = pactsService.createEnvelope("profile", "profile_request", payload);
+        ValidationResult result = pactsService.validate(envelope);
+
+        Assertions.assertTrue(result.isValid(), "Profile request should be valid: " + result.getErrorMessage());
+        logger.info("Profile request validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Null payload should be handled gracefully")
+    void nullPayload_shouldBeHandledGracefully() {
+        logger.info("Testing null payload handling");
+
+        Exception exception = Assertions.assertThrows(Exception.class, () -> {
+            sendMessage(null, "player", "player_request");
+        });
+        logger.debug("Null payload correctly threw exception: {}", exception.getMessage());
+
+        logger.info("Null payload handling test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Empty payload should fail validation appropriately")
+    void emptyPayload_shouldFailValidation() {
+        logger.info("Testing empty payload validation");
+
+        var payload = objectMapper.createObjectNode();
+        sendMessageAndExpectFailure(payload, "player", "player_request", null);
+
+        logger.info("Empty payload validation test completed successfully");
+    }
+
+    @Test
+    @DisplayName("Multiple rapid validations should perform adequately")
+    void multipleRapidValidations_shouldPerformAdequately() {
+        logger.info("Testing performance with multiple rapid validations");
+
+        long startTime = System.currentTimeMillis();
+
+        for (int i = 0; i < 100; i++) {
+            var payload = objectMapper.createObjectNode()
+                    .put("request_type", "PERFORMANCE_TEST_" + i)
+                    .put("target_id", UUID.randomUUID().toString())
+                    .put("date", Instant.now().toString());
+
+            Envelope envelope = pactsService.createEnvelope("player", "player_request", payload);
+            ValidationResult result = pactsService.validate(envelope);
+            Assertions.assertTrue(result.isValid(), "Validation " + i + " should succeed");
+        }
+
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        logger.info("Completed 100 validations in {} ms (avg: {} ms per validation)",
+                duration, duration / 100.0);
+
+        // Performance assertion - should complete 100 validations in reasonable time
+        Assertions.assertTrue(duration < 5000,
+                "100 validations should complete in under 5 seconds, took: " + duration + "ms");
+    }
+
+}

--- a/java/src/test/java/net/hydrius/pacts/spring/TestListener.java
+++ b/java/src/test/java/net/hydrius/pacts/spring/TestListener.java
@@ -1,0 +1,59 @@
+package net.hydrius.pacts.spring;
+
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static net.hydrius.pacts.spring.SpringBootMessageTest.QUEUE;
+import net.hydrius.pacts.core.ValidationResult;
+import net.hydrius.pacts.impl.PactsService;
+import net.hydrius.pacts.model.Envelope;
+
+@Component
+public class TestListener {
+
+    private final Logger logger = LoggerFactory.getLogger(TestListener.class);
+    private final ObjectMapper objectMapper;
+    private final PactsService pactsService;
+
+    @Autowired
+    public TestListener(ObjectMapper objectMapper, PactsService pactsService) {
+        this.objectMapper = objectMapper;
+        this.pactsService = pactsService;
+    }
+
+    @RabbitListener(queues = QUEUE)
+    void handleMessage(byte[] raw) {
+        try {
+            String body = new String(raw, StandardCharsets.UTF_8);
+            logger.debug("Received message: {} bytes", raw.length);
+            logger.trace("Message content: {}", body);
+
+            Envelope envelope = pactsService.parseEnvelope(body);
+            ValidationResult result = pactsService.validate(envelope);
+
+            if (!result.isValid()) {
+                logger.error("Message validation failed: {}", result.getErrors());
+                throw new IllegalArgumentException("Message validation failed: " + result.getErrors());
+            }
+
+            JsonNode data = objectMapper.valueToTree(envelope.getData());
+            String type = data.path("request_type").asText("UNKNOWN");
+            String targetId = data.path("target_id").asText("UNKNOWN");
+
+            logger.info("Successfully processed message - Type: {}, Target: {}, Schema: {}/{}",
+                    type, targetId, envelope.getHeader().getSchemaCategory(), envelope.getHeader().getSchemaName());
+        } catch (Exception e) {
+            logger.error("Failed to process message: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to process message: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/java/src/test/resources/application.yml
+++ b/java/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+logging:
+  level:
+    root: INFO
+    net.hydrius: DEBUG
+    org.springframework.amqp.rabbit.core.RabbitTemplate: DEBUG
+    org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer: DEBUG
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
Adds the Jackson JavaTimeModule to ObjectMappers to parse Instants. Adds a basic Spring Boot and Rabbit implementation to test messaging between producers and consumers. Tests use actual schemas, but the payloads do not reflect on actual request types.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds JavaTimeModule to all ObjectMappers to correctly parse/serialize Instant values, and introduces an end-to-end Spring Boot + RabbitMQ test setup to validate producer/consumer messaging with real schemas.

- **New Features**
  - Register JavaTimeModule in SchemaLoader, Validator, and PactsService.
  - Spring Boot test app with RabbitMQ (Testcontainers) to exercise envelope creation, validation, and message flow.
  - Listener, exchange/queue/binding config; tests cover valid/invalid payloads and basic performance.

- **Dependencies**
  - Bump to 0.0.4.
  - Upgrade Jackson (core/databind 2.17.1) and add jackson-datatype-jsr310.
  - Adopt Spring Boot 3.3.2 and Testcontainers 1.21.3 BOMs.
  - Add spring-boot-starter-test, spring-boot-starter-amqp, spring-boot-starter-logging, and Testcontainers (core, rabbitmq, junit-jupiter).
  - Add JitPack and Central repositories.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for Java 8 date/time types in JSON (de)serialization, improving compatibility with time-based fields.
- Tests
  - Added Spring Boot + Testcontainers integration tests with RabbitMQ, a test listener, and logging config to validate message publishing, consumption, and schema validation scenarios.
- Chores
  - Bumped project version to 0.0.4.
  - Centralized dependency version management via BOMs and updated test/runtime dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->